### PR TITLE
Made group restriction less strict if no resolution set

### DIFF
--- a/vendor/bdunogier/subber/lib/ReleaseSubtitles/CompatibilityMatcher.php
+++ b/vendor/bdunogier/subber/lib/ReleaseSubtitles/CompatibilityMatcher.php
@@ -34,8 +34,12 @@ class CompatibilityMatcher
                 continue;
             }
             if ( isset( $subtitle->group ) && $subtitle->group != $release->group ) {
-                $subtitle->setIncompatible();
-                continue;
+                // At this point, the source is different, but the source is the same.
+                // we may test if the resolution is set on sub & release. If it ain't, they're probably compatible
+                if ( isset( $subtitle->resolution ) || isset( $release->resolution ) ) {
+                    $subtitle->setIncompatible();
+                    continue;
+                }
             }
         }
 

--- a/vendor/bdunogier/subber/spec/ReleaseSubtitles/CompatibilityMatcherSpec.php
+++ b/vendor/bdunogier/subber/spec/ReleaseSubtitles/CompatibilityMatcherSpec.php
@@ -32,18 +32,18 @@ class CompatibilityMatcherSpec extends ObjectBehavior
         $result->shouldContainIncompatibleSubtitles( ['c', 'd'] );
     }
 
-    function it_marks_as_incompatible_subtitles_with_a_known_group_different_from_the_release()
+    function it_marks_as_incompatible_subtitles_with_a_resolution_and_a_known_group_different_from_the_release()
     {
         $release = new Release( ['group' => 'killers'] );
         $subtitles = [
             new Subtitle( ['name' => 'a', 'group' => 'killers'] ),
             new Subtitle( ['name' => 'b', 'group' => 'lol'] ),
-            new Subtitle( ['name' => 'c', 'group' => 'dimension'] )
+            new Subtitle( ['name' => 'c', 'group' => 'dimension', 'resolution' => '720p'] )
         ];
 
         $result = $this->match( $release, $subtitles );
         $result->shouldBeAnArrayOfTestedReleaseSubtitles();
-        $result->shouldContainIncompatibleSubtitles( ['b', 'c'] );
+        $result->shouldContainIncompatibleSubtitles( ['c'] );
     }
 
     function it_marks_as_incompatible_non_repacked_subtitles_when_applicable()
@@ -61,6 +61,20 @@ class CompatibilityMatcherSpec extends ObjectBehavior
         $result->shouldContainIncompatibleSubtitles( ['a', 'b'] );
     }
 
+    function it_doesnt_mark_as_incompatible_hdtv_subtitles_from_a_different_group_if_no_resolution_is_set()
+    {
+        $release = new Release( ['source' => 'hdtv', 'group' => 'lol'] );
+        $subtitles = [
+            new Subtitle( ['name' => 'a', 'source' => 'hdtv', 'group' => 'dimension'] ),
+            new Subtitle( ['name' => 'b', 'source' => 'web-dl', 'group' => 'dimension'] ),
+        ];
+
+        $result = $this->match( $release, $subtitles );
+        $result->shouldBeAnArrayOfTestedReleaseSubtitles();
+        $result->shouldNotContainIncompatibleSubtitles( ['a'] );
+        $result->shouldContainIncompatibleSubtitles( ['b'] );
+    }
+
     function getMatchers()
     {
         return [
@@ -76,14 +90,14 @@ class CompatibilityMatcherSpec extends ObjectBehavior
                 }
                 return true;
             },
-            // tests that $result contains ONLY $wantedSubtitles as Compatible
+            // tests that $result contains $wantedSubtitles as Compatible
             'containCompatibleSubtitles' => function( array $subtitles, array $wantedSubtitlesNames ) {
                 return $this->containSubtitles( $subtitles, $wantedSubtitlesNames, TestedReleaseSubtitle::COMPATIBLE );
             },
-            // tests that $result contains ONLY $wantedSubtitles as Inompatible
+            // tests that $result contains $wantedSubtitles as Incompatible
             'containIncompatibleSubtitles' => function( array $subtitles, array $wantedSubtitlesNames ) {
                 return $this->containSubtitles( $subtitles, $wantedSubtitlesNames, TestedReleaseSubtitle::INCOMPATIBLE );
-            }
+            },
         ];
     }
 


### PR DESCRIPTION
Requiring that the Release Group is identical on the Subtitle is a bit too harsh.

Usually, as long as the source _and_ the resolution are identical, we can consider the releases as not incompatible.