### PR TITLE
Made stash cache TTL dynamic

### DIFF
--- a/vendor/bdunogier/subber/bundle/Resources/config/services.yml
+++ b/vendor/bdunogier/subber/bundle/Resources/config/services.yml
@@ -59,6 +59,10 @@ services:
         arguments:
             - @bd_subber.release_subtitles.index_factory.scrapper_based
             - @stash.default_cache
+            - @bd_subber.release_subtitles.index_factory.cache_ttl_provider
+
+    bd_subber.release_subtitles.index_factory.cache_ttl_provider:
+        class: BD\Subber\ReleaseSubtitles\IndexFactory\IndexCacheTtlProvider
 
     bd_subber.release_subtitles.index_factory:
         class: BD\Subber\ReleaseSubtitles\IndexFactory

--- a/vendor/bdunogier/subber/lib/Cache/CacheTtlProvider.php
+++ b/vendor/bdunogier/subber/lib/Cache/CacheTtlProvider.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace BD\Subber\Cache;
+
+/**
+ * Calculates cache time-to-live (TTL).
+ */
+interface CacheTtlProvider
+{
+    /**
+     * Returns the Cache TTL to use for $item
+     * @param mixed $item
+     * @return int
+     */
+    public function get( $item );
+}

--- a/vendor/bdunogier/subber/lib/ReleaseSubtitles/IndexFactory/IndexCacheTtlProvider.php
+++ b/vendor/bdunogier/subber/lib/ReleaseSubtitles/IndexFactory/IndexCacheTtlProvider.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace BD\Subber\ReleaseSubtitles\IndexFactory;
+
+use BD\Subber\Cache\CacheTtlProvider;
+
+class IndexCacheTtlProvider implements CacheTtlProvider
+{
+
+    /**
+     * Returns the Cache TTL to use for $item
+     * @param \BD\Subber\ReleaseSubtitles\Index $index
+     * @return int
+     */
+    public function get( $index )
+    {
+        if ( $index->hasBestSubtitle() ) {
+            if ( $index->getBestSubtitle()->getRating() > 0 ) {
+                $ttl = 43200; // 12 hours
+            } else {
+                $ttl = 7200; // 2 hours
+            }
+        } else {
+            $ttl = 3600;
+        }
+        return $ttl;
+    }
+}

--- a/vendor/bdunogier/subber/lib/ReleaseSubtitles/IndexFactory/StashCachedIndexFactory.php
+++ b/vendor/bdunogier/subber/lib/ReleaseSubtitles/IndexFactory/StashCachedIndexFactory.php
@@ -1,6 +1,8 @@
 <?php
 namespace BD\Subber\ReleaseSubtitles\IndexFactory;
 
+use BD\Subber\Cache\CacheTtlProvider;
+use BD\Subber\ReleaseSubtitles\Index;
 use BD\Subber\ReleaseSubtitles\IndexFactory;
 use Stash\Interfaces\PoolInterface;
 
@@ -13,10 +15,11 @@ class StashCachedIndexFactory implements IndexFactory
      */
     private $cachePool;
 
-    public function __construct( IndexFactory $cachedFactory, PoolInterface $cachePool )
+    public function __construct( IndexFactory $cachedFactory, PoolInterface $cachePool, CacheTtlProvider $cacheTtlProvider )
     {
         $this->cachedFactory = $cachedFactory;
         $this->cachePool = $cachePool;
+        $this->ttl = $cacheTtlProvider;
     }
 
     public function build( $releaseName )
@@ -25,7 +28,7 @@ class StashCachedIndexFactory implements IndexFactory
         if ( $cacheItem->isMiss() )
         {
             $index = $this->cachedFactory->build( $releaseName );
-            $cacheItem->set( $index );
+            $cacheItem->set( $index, $this->ttl->get( $index ) );
         }
 
         return $cacheItem->get();

--- a/vendor/bdunogier/subber/spec/ReleaseSubtitles/IndexFactory/IndexCacheTtlProviderSpec.php
+++ b/vendor/bdunogier/subber/spec/ReleaseSubtitles/IndexFactory/IndexCacheTtlProviderSpec.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace spec\BD\Subber\ReleaseSubtitles\IndexFactory;
+
+use BD\Subber\ReleaseSubtitles\TestedReleaseSubtitle;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+class IndexCacheTtlProviderSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType('BD\Subber\ReleaseSubtitles\IndexFactory\IndexCacheTtlProvider');
+    }
+
+    /**
+     * @param \BD\Subber\ReleaseSubtitles\Index $index
+     */
+    function it_sets_ttl_to_one_hour_when_no_best_subtitles( $index )
+    {
+        $index->hasBestSubtitle()->willReturn( false );
+
+        $this->get( $index )->shouldReturn( 3600 );
+    }
+
+    /**
+     * @param \BD\Subber\ReleaseSubtitles\Index $index
+     * @param \BD\Subber\ReleaseSubtitles\TestedReleaseSubtitle $subtitle
+     */
+    function it_sets_ttl_to_two_hours_when_best_subtitles_with_zero_or_negative_rating( $index, $subtitle )
+    {
+        $index->hasBestSubtitle()->willReturn( true );
+        $index->getBestSubtitle()->willReturn( $subtitle );
+
+        $subtitle->getRating()->willReturn( -1 );
+
+        $this->get( $index )->shouldReturn( 7200 );
+    }
+
+    /**
+     * @param \BD\Subber\ReleaseSubtitles\Index $index
+     * @param \BD\Subber\ReleaseSubtitles\TestedReleaseSubtitle $subtitle
+     */
+    function it_sets_ttl_to_one_half_day_when_best_subtitle_with_positive_rating( $index, $subtitle )
+    {
+        $index->hasBestSubtitle()->willReturn( true );
+        $index->getBestSubtitle()->willReturn( $subtitle );
+
+        $subtitle->getRating()->willReturn( 2 );
+
+        $this->get( $index )->shouldReturn( 43200 );
+    }
+}

--- a/vendor/bdunogier/subber/spec/ReleaseSubtitles/IndexFactory/StashCachedIndexFactorySpec.php
+++ b/vendor/bdunogier/subber/spec/ReleaseSubtitles/IndexFactory/StashCachedIndexFactorySpec.php
@@ -12,10 +12,11 @@ class StashCachedIndexFactorySpec extends ObjectBehavior
     /**
      * @param \BD\Subber\ReleaseSubtitles\IndexFactory $cachedIndexFactory
      * @param \Stash\Interfaces\PoolInterface $cachePool
+     * @param \BD\Subber\Cache\CacheTtlProvider $cacheTtlProvider
      */
-    function let( $cachedIndexFactory, $cachePool )
+    function let( $cachedIndexFactory, $cachePool, $cacheTtlProvider )
     {
-        $this->beConstructedWith( $cachedIndexFactory, $cachePool );
+        $this->beConstructedWith( $cachedIndexFactory, $cachePool, $cacheTtlProvider );
     }
 
     function it_is_initializable(  )
@@ -33,7 +34,7 @@ class StashCachedIndexFactorySpec extends ObjectBehavior
         $subtitles = ['release_1' => [], 'release_2'];
 
         $cacheItem->isMiss()->willReturn( true );
-        $cacheItem->set( $subtitles )->shouldBeCalled();
+        $cacheItem->set( $subtitles, null )->shouldBeCalled();
         $cacheItem->get()->willReturn( $subtitles );
 
         $cachePool->getItem( 'release.name-group', Argument::type('string') )->willReturn( $cacheItem );
@@ -44,11 +45,10 @@ class StashCachedIndexFactorySpec extends ObjectBehavior
     }
 
     /**
-     * @param \BD\Subber\ReleaseSubtitles\IndexFactory $cachedIndexFactory
      * @param \Stash\Interfaces\PoolInterface $cachePool
      * @param  \Stash\Interfaces\ItemInterface $cacheItem
      */
-    function it_uses_valid_cache_if_it_exists( $cachedIndexFactory, $cachePool, $cacheItem )
+    function it_uses_valid_cache_if_it_exists( $cachePool, $cacheItem )
     {
         $subtitles = ['release_1' => [], 'release_2'];
 


### PR DESCRIPTION
A CacheTtlProvider will, given an item, return the suitable TTL.

See [spec/ReleaseSubtitles/IndexFactory/IndexCacheTtlProviderSpec.php](https://github.com/bdunogier/subber/blob/dynamic_stash_cache_ttl/vendor/bdunogier/subber/lib/Cache/CacheTtlProvider.php) for the current behaviour.